### PR TITLE
chore // bump release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -21,6 +22,12 @@ jobs:
         with:
           go-version: '1.25'
           cache: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.10.0
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,16 +27,16 @@ builds:
 
 archives:
   - formats:
-      - zip
+      - tar.gz
     files:
       # demo configuration files
-      - pg_auth
-      - pg_config.ini
-      - pgboundary.ini
-      # full readme + license
-      - README.md
-      - pgboundary.png
-      - LICENSE
+      - "pg_auth"
+      - "pg_config.ini"
+      - "pgboundary.ini"
+      # documentation and assets
+      - "README.md"
+      - "pgboundary.png"
+      - "LICENSE"
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -61,32 +61,23 @@ release:
     
     Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
 
-brews:
+homebrew_casks:
   - name: pgboundary
     commit_msg_template: "chore: Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    directory: HomebrewFormula
+    directory: Casks
     homepage: "https://github.com/sigterm-de/pgboundary"
     description: "A wrapper around boundary and pgbouncer CLI for integration into IDE/database tooling"
-    install: |
-      # Install the binary into Homebrew's bin directory
-      bin.install "pgboundary"
-  
-      # Install example configuration files into a documentation directory
-      doc.install "pgboundary.ini"
-      doc.install "pg_auth"
-      doc.install "pg_config.ini"
+    license: "MIT"
+    binary: pgboundary
     caveats: |
-      The example configuration file has been installed at:
-        #{doc}/pgboundary.ini
-        #{doc}/pg_config.ini
-        #{doc}/pg_auth
-      You may copy and modify it for your use:
-        cp #{doc}/pgboundary.ini ~/pgboundary/pgboundary.ini
-        cp #{doc}/pg_config.ini ~/pgboundary/pg_config.ini
-        cp #{doc}/pg_auth ~/pgboundary/pg_auth
-    dependencies:
-      - name: boundary
-      - name: pgbouncer
+      pgboundary requires boundary and pgbouncer to be installed separately:
+        brew install boundary
+        brew install pgbouncer
+      
+      Example configuration files are included in the archive and can be found at:
+        #{staged_path}/pgboundary.ini
+        #{staged_path}/pg_config.ini
+        #{staged_path}/pg_auth
     repository:
       owner: sigterm-de
       name: pgboundary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,6 +54,40 @@ changelog:
       - "^test:"
       - "^chore: Brew formula update"
 
+sboms:
+  - artifacts: archive
+    documents:
+      - "${artifact}.spdx.json"
+    cmd: syft
+    args:
+      - "${artifact}"
+      - "--output"
+      - "spdx-json=${document}"
+
+signs:
+  - id: checksum
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: checksum
+  - id: sbom
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: sbom
+
 release:
   footer: >-
     

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A target is a configuration item inside Boundary defining to which entity a conn
     Or install via brew  
     ```
     brew tap sigterm-de/pgboundary https://github.com/sigterm-de/pgboundary
-    brew install pgboundary
+    brew install --cask pgboundary
     ```
 
 3. Copy the files `pgboundary.ini`, `pg_config.ini` and `pg_auth` to a convenient place. The binary tries to find them in the following locations:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,84 @@ pgboundary version -v
 - In case the boundary authentication and connection is `OK`, but pgbouncer is `NOK`, please run pgbouncer manually to get more feedback - `pgbouncer --daemon <path>/<to>/pg_config.ini`
 - There might be configuration relicts in `pg_config.ini`. To purge them, please run `pgboundary shutdown` (until a dedicated command is available)
 
+## Security & Verification
+
+### Release Signatures
+
+All releases are signed using [cosign](https://docs.sigstore.dev/) with keyless signing tied to this GitHub repository. This provides cryptographic proof that releases come from the official repository.
+
+#### Verifying Release Integrity
+
+1. **Download the release files**:
+   ```bash
+   # Download the binary archive, checksums, and signature files
+   wget https://github.com/sigterm-de/pgboundary/releases/download/v1.0.0/pgboundary_Linux_x86_64.tar.gz
+   wget https://github.com/sigterm-de/pgboundary/releases/download/v1.0.0/pgboundary_1.0.0_checksums.txt
+   wget https://github.com/sigterm-de/pgboundary/releases/download/v1.0.0/pgboundary_1.0.0_checksums.txt.sig
+   wget https://github.com/sigterm-de/pgboundary/releases/download/v1.0.0/pgboundary_1.0.0_checksums.txt.pem
+   ```
+
+2. **Install cosign** (if not already installed):
+   ```bash
+   # Install cosign
+   go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+   # Or use your package manager (brew, apt, etc.)
+   ```
+
+3. **Verify the signature**:
+   ```bash
+   cosign verify-blob \
+     --certificate-identity 'https://github.com/sigterm-de/pgboundary/.github/workflows/release.yml@refs/tags/v1.0.0' \
+     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+     --cert pgboundary_1.0.0_checksums.txt.pem \
+     --signature pgboundary_1.0.0_checksums.txt.sig \
+     ./pgboundary_1.0.0_checksums.txt
+   ```
+
+4. **Verify file integrity**:
+   ```bash
+   # Check that your downloaded archive matches the signed checksums
+   sha256sum --check --ignore-missing pgboundary_1.0.0_checksums.txt
+   ```
+
+**Note**: Replace `v1.0.0` with the actual version you're downloading.
+
+### Software Bill of Materials (SBOM)
+
+Each release includes a comprehensive Software Bill of Materials (SBOM) generated using [Syft](https://github.com/anchore/syft). The SBOM documents all dependencies, versions, and security metadata in SPDX-JSON format.
+
+#### SBOM Files
+
+For each release archive, you'll find corresponding SBOM files:
+- `pgboundary_Linux_x86_64.tar.gz.spdx.json` - SBOM for Linux x86_64 build
+- `pgboundary_Darwin_arm64.tar.gz.spdx.json` - SBOM for macOS ARM64 build
+- And corresponding files for other architectures
+
+#### Verifying SBOM Integrity
+
+SBOM files are also signed with cosign and included in the checksums:
+
+```bash
+# Verify SBOM signature
+cosign verify-blob \
+  --certificate-identity 'https://github.com/sigterm-de/pgboundary/.github/workflows/release.yml@refs/tags/v1.0.0' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  --cert pgboundary_Linux_x86_64.tar.gz.spdx.json.pem \
+  --signature pgboundary_Linux_x86_64.tar.gz.spdx.json.sig \
+  ./pgboundary_Linux_x86_64.tar.gz.spdx.json
+
+# Verify SBOM checksum
+sha256sum --check --ignore-missing pgboundary_1.0.0_checksums.txt
+```
+
+#### Using SBOM Data
+
+The SBOM can be used for:
+- **Vulnerability scanning**: Import into security tools for dependency analysis
+- **License compliance**: Review all dependency licenses
+- **Supply chain security**: Track the complete software supply chain
+- **Audit requirements**: Meet compliance requirements for software composition
+
 ## Limitations
 
 - only **OIDC** authentication is supported


### PR DESCRIPTION
- full go-releaser v2 syntax
- migrate to `homebrew_cask`
- sign artifacts
- generate SBOM